### PR TITLE
Rails 6.1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 * No unreleased changes
 
+## 6.1.7.1.0 / 2023-01-21
+### Fixed
+* Bump rails to 6.1.7.1
+
 ## 6.1.7.0 / 2022-09-29
 ### Fixed
 * Bump rails to 6.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
 ## [Unreleased]
-* No unreleased changes
-
-## 6.1.7.1.0 / 2023-01-21
 ### Fixed
 * Bump rails to 6.1.7.1
 

--- a/lib/active_model/caution/version.rb
+++ b/lib/active_model/caution/version.rb
@@ -1,6 +1,6 @@
 module ActiveModel
   module Caution
-    RAILS_VERSION = '6.1.7'.freeze
+    RAILS_VERSION = '6.1.7.1'.freeze
     GEM_REVISION  = '0'.freeze
 
     # Gem version:


### PR DESCRIPTION
Add rails 6.1.7.1 version to allow CVEs to be fixed in projects/repos that use activemodel-caution