### PR TITLE
Add version to support Rails 6.1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* No unreleased changes
+### Fixed
+* Bump rails to 6.1.7.3
 
 ## 6.1.7.1.0 / 2023-01-24
 ### Fixed

--- a/lib/active_model/caution/version.rb
+++ b/lib/active_model/caution/version.rb
@@ -1,6 +1,6 @@
 module ActiveModel
   module Caution
-    RAILS_VERSION = '6.1.7.1'.freeze
+    RAILS_VERSION = '6.1.7.3'.freeze
     GEM_REVISION  = '0'.freeze
 
     # Gem version:


### PR DESCRIPTION
Version number bump only.

No significant changes in Rails between 6.1.7.1 and 6.1.7.3 that requires further action.
https://github.com/rails/rails/compare/v6.1.7.1...v6.1.7.3